### PR TITLE
Add logger warning to failing fetch metadata failure.

### DIFF
--- a/actionpack/lib/action_dispatch/http/resource_isolation_policy.rb
+++ b/actionpack/lib/action_dispatch/http/resource_isolation_policy.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "action_view"
+
 module ActionDispatch #:nodoc:
   class ResourceIsolationPolicy
     class Middleware
@@ -91,7 +93,7 @@ module ActionDispatch #:nodoc:
            Permissions.new(request, assets_prefix).forbidden?
 
           if request.resource_isolation_policy.log_warning_on_fetch_metadata_failure
-            logger.warn "Fetch Metadata header didn't match request"
+            logger(request).warn "Fetch Metadata header didn't match request"
           end
 
           response = FORBIDDEN_RESPONSE_APP.call(request)
@@ -102,8 +104,8 @@ module ActionDispatch #:nodoc:
 
       private
 
-      def logger
-        ActiveSupport::Logger.new($stderr)
+      def logger(request)
+        request.logger || ActionView::Base.logger || ActiveSupport::Logger.new($stderr)
       end
 
       attr_reader :app, :assets_prefix

--- a/actionpack/lib/action_dispatch/http/resource_isolation_policy.rb
+++ b/actionpack/lib/action_dispatch/http/resource_isolation_policy.rb
@@ -90,6 +90,10 @@ module ActionDispatch #:nodoc:
         if request.resource_isolation_policy &&
            Permissions.new(request, assets_prefix).forbidden?
 
+          if request.resource_isolation_policy.log_warning_on_fetch_metadata_failure
+            logger.warn "Fetch Metadata header didn't match request"
+          end
+
           response = FORBIDDEN_RESPONSE_APP.call(request)
         end
 
@@ -97,6 +101,10 @@ module ActionDispatch #:nodoc:
       end
 
       private
+
+      def logger
+        ActiveSupport::Logger.new($stderr)
+      end
 
       attr_reader :app, :assets_prefix
     end
@@ -115,10 +123,11 @@ module ActionDispatch #:nodoc:
 
     DEFAULT_SAME_SITE_POLICY = false
 
-    attr_accessor :same_site
+    attr_accessor :same_site, :log_warning_on_fetch_metadata_failure
 
     def initialize
       @same_site = DEFAULT_SAME_SITE_POLICY
+      self.log_warning_on_fetch_metadata_failure = true
 
       yield self if block_given?
     end

--- a/actionpack/lib/action_dispatch/http/resource_isolation_policy.rb
+++ b/actionpack/lib/action_dispatch/http/resource_isolation_policy.rb
@@ -92,7 +92,7 @@ module ActionDispatch #:nodoc:
         if request.resource_isolation_policy &&
            Permissions.new(request, assets_prefix).forbidden?
 
-          if request.resource_isolation_policy.log_warning_on_fetch_metadata_failure
+          if request.resource_isolation_policy.log_warning_on_failure
             logger(request).warn "Fetch Metadata header didn't match request"
           end
 
@@ -125,11 +125,11 @@ module ActionDispatch #:nodoc:
 
     DEFAULT_SAME_SITE_POLICY = false
 
-    attr_accessor :same_site, :log_warning_on_fetch_metadata_failure
+    attr_accessor :same_site, :log_warning_on_failure
 
     def initialize
-      @same_site = DEFAULT_SAME_SITE_POLICY
-      self.log_warning_on_fetch_metadata_failure = true
+      self.same_site = DEFAULT_SAME_SITE_POLICY
+      self.log_warning_on_failure = true
 
       yield self if block_given?
     end

--- a/actionpack/test/dispatch/resource_isolation_policy_test.rb
+++ b/actionpack/test/dispatch/resource_isolation_policy_test.rb
@@ -28,7 +28,9 @@ class ResourceIsolationPolicyTest
       end
 
       def call(env)
-        env["action_dispatch.resource_isolation_policy"] = ActionDispatch::ResourceIsolationPolicy.new
+        env["action_dispatch.resource_isolation_policy"] = ActionDispatch::ResourceIsolationPolicy.new do |policy|
+          policy.log_warning_on_fetch_metadata_failure = false
+        end
         @app.call(env)
       end
     end
@@ -106,7 +108,6 @@ class ResourceIsolationPolicyTest
         "sec-fetch-dest": "document",
         "sec-fetch-mode": "navigate"
       }
-
       assert_response 403
       assert_match "Blocked request: POST /", response.body
     end
@@ -245,6 +246,7 @@ class ResourceIsolationPolicyTest
       def call(env)
         env["action_dispatch.resource_isolation_policy"] = ActionDispatch::ResourceIsolationPolicy.new do |policy|
           policy.same_site = false
+          policy.log_warning_on_fetch_metadata_failure = false
         end
         @app.call(env)
       end

--- a/actionpack/test/dispatch/resource_isolation_policy_test.rb
+++ b/actionpack/test/dispatch/resource_isolation_policy_test.rb
@@ -29,7 +29,7 @@ class ResourceIsolationPolicyTest
 
       def call(env)
         env["action_dispatch.resource_isolation_policy"] = ActionDispatch::ResourceIsolationPolicy.new do |policy|
-          policy.log_warning_on_fetch_metadata_failure = false
+          policy.log_warning_on_failure = false
         end
         @app.call(env)
       end
@@ -246,7 +246,7 @@ class ResourceIsolationPolicyTest
       def call(env)
         env["action_dispatch.resource_isolation_policy"] = ActionDispatch::ResourceIsolationPolicy.new do |policy|
           policy.same_site = false
-          policy.log_warning_on_fetch_metadata_failure = false
+          policy.log_warning_on_failure = false
         end
         @app.call(env)
       end


### PR DESCRIPTION
I enabled it by default and disabled it in specs. It's possible we need to get a logger instance from somewhere else, but we're pretty high up in the call stack here, so perhaps this is the right way.